### PR TITLE
Fix #4: Get File Size

### DIFF
--- a/core.py
+++ b/core.py
@@ -6,7 +6,16 @@ import hashlib
 def getRelPath(path):
 	path = os.path.relpath(path)
 	return path
-## Return a md5 checksum object after 
+## This takes a passed path,
+## retrieves the absolute path
+## as it relates to the working
+## directory and returns the file
+## size in bytes
+def getFileSize(path):
+	path = abspath(path)
+    fileSize = os.path.getsize(path)
+    return fileSize
+## Return a md5 checksum object after
 ## usinf getRelPath to convert the path
 ## into a relative path as related to
 ## the current working directory
@@ -17,6 +26,6 @@ def getMd5(path):
 ## Same as the above function but
 ## for SHA1 hashes instead
 def getSHA1(path):
-	path = getRelPath(path)	
+	path = getRelPath(path)
 	checksum = sha1.new(path);
 	return checksum

--- a/getFileSize.py
+++ b/getFileSize.py
@@ -1,0 +1,8 @@
+import os
+
+## The following function returns the size of a file, in bytes
+## To use, call the function as follows print getFileSize("path/to/file")
+def getFileSize(path):
+
+    fileSize = os.path.getsize(path)
+    return fileSize

--- a/getFileSize.py
+++ b/getFileSize.py
@@ -1,8 +1,0 @@
-import os
-
-## The following function returns the size of a file, in bytes
-## To use, call the function as follows print getFileSize("path/to/file")
-def getFileSize(path):
-
-    fileSize = os.path.getsize(path)
-    return fileSize


### PR DESCRIPTION
Fixes #4. Implemented a wrapper function to call the native `path.getsize()` function in Python.